### PR TITLE
Upgrade to Django3

### DIFF
--- a/exo_changelog/__init__.py
+++ b/exo_changelog/__init__.py
@@ -1,2 +1,2 @@
 from .change import Change, swappable_dependency  # NOQA
-__version__ = '0.1.6'
+__version__ = '0.1.7'

--- a/exo_changelog/change.py
+++ b/exo_changelog/change.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 
 
 @python_2_unicode_compatible

--- a/exo_changelog/exceptions.py
+++ b/exo_changelog/exceptions.py
@@ -1,7 +1,8 @@
 from __future__ import unicode_literals
 
+from six import python_2_unicode_compatible
+
 from django.db.utils import DatabaseError
-from django.utils.encoding import python_2_unicode_compatible
 
 
 class AmbiguityError(Exception):

--- a/exo_changelog/graph.py
+++ b/exo_changelog/graph.py
@@ -4,10 +4,11 @@ import sys
 import warnings
 from collections import deque
 
+from six import python_2_unicode_compatible
+
 from django.db.migrations.state import ProjectState
 from django.utils import six
 from django.utils.datastructures import OrderedSet
-from django.utils.encoding import python_2_unicode_compatible
 from django.db.migrations.graph import Node
 
 from .exceptions import CircularDependencyError, NodeNotFoundError

--- a/exo_changelog/models.py
+++ b/exo_changelog/models.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
+
 from django.utils.timezone import now
 from django.db import models
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,8 @@ setenv =
 commands = coverage run --source django_changelog runtests.py
 deps =
     django-111: Django>=1.11,<1.12
-    django-20: Django>=2.0,<2.1
+    django-20: Django>=2.0,<2.8
+    django-30: Django>=3.0,<4.0
     -r{toxinidir}/requirements_dev.txt
 basepython =
     py36: python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist =
+    {py36}-django-30
     {py36}-django-20
     {py36}-django-111
 skip_missing_interpreters=true


### PR DESCRIPTION
https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis